### PR TITLE
i.eとe.gのピリオドをエスケープ

### DIFF
--- a/src/components/transtex.tsx
+++ b/src/components/transtex.tsx
@@ -67,7 +67,7 @@ export default () => {
 
         let regStr: RegExp
         if(isChrome){
-            regStr = new RegExp("(?<!al)(?<!vs)(?<!e.g)(?<!i.e)\\. ")
+            regStr = new RegExp("(?<!al)(?<!vs)(?<!e\\.g)(?<!i\\.e)\\. ")
         } else {
             regStr = new RegExp("\\. ")
         }


### PR DESCRIPTION
i.eとe.gのピリオドが任意の文字に反応しiae.やeag.などの文末のときに改行されないためエスケープしました．

![スクリーンショット 2022-06-07 133908](https://user-images.githubusercontent.com/82485743/172311384-9ae72f4c-fdd5-43b2-a3d3-fb9c3e8b5de9.png)
