### PR TITLE
翻訳失敗メッセージ追加&フォーマット済み文字列のセット

### DIFF
--- a/src/components/transtex.tsx
+++ b/src/components/transtex.tsx
@@ -171,6 +171,7 @@ export default () => {
 {${item}${item.slice(-1) === "." ? "" : "."}}
 {}`)
         })
+        setTexStrings(out.join("\n"))
     }
 
 
@@ -199,7 +200,11 @@ export default () => {
         })
         .then(res => res.text())
 
-        setTexStrings(data)
+        if( data === "" ){
+            setTexStrings("翻訳に失敗しました。")
+        } else {
+            setTexStrings(data)
+        }
     }
 
 


### PR DESCRIPTION
`https://transtex.netlify.app/.netlify/functions/translate` が何らかの理由でボディを返さないことがあります。
空文字列がセットされるので原因がわかりにくいのでエラーメッセージをセットするようにします。
またこの場合、TeXのフォーマット済み文字列がセットされず詰んでしまうので `formatTemplate()` 内でセットするようにしました。
Translate(Local)の左隣にTeXのフォーマットだけするボタンがあるといい気がしましたがそこまではできませんでした。